### PR TITLE
Select system for toBest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ Converter.prototype.to = function (to) {
 /**
 * Converts the unit to the best available unit.
 */
-Converter.prototype.toBest = function (system = null) {
+Converter.prototype.toBest = function (system) {
   if(!this.origin)
     throw new Error('.toBest must be called after .from');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,11 +105,12 @@ Converter.prototype.to = function (to) {
 /**
 * Converts the unit to the best available unit.
 */
-Converter.prototype.toBest = function() {
+Converter.prototype.toBest = function (system = null) {
   if(!this.origin)
     throw new Error('.toBest must be called after .from');
 
   var best;
+  var targetSystem = system || this.origin.system;
   /**
     Looks through every possibility for the 'best' available unit.
     i.e. Where the value has the fewest numbers before the decimal point,
@@ -117,7 +118,7 @@ Converter.prototype.toBest = function() {
   */
   each(this.possibilities(), function(possibility) {
     var unit = this.describe(possibility);
-    if (unit.system === this.origin.system) {
+    if (unit.system === targetSystem) {
       var result = this.to(possibility);
       if (!best || (result >= 1 && result < best.val)) {
         best = {


### PR DESCRIPTION
Allow selection of system to use for toBest, so conversion between systems is easier (i.e. `.toBest('metric')` or `.toBest('imperial')`. Passing in `'default'` or just calling `.toBest()` uses origin system.
