### PR TITLE
[BUG] Unhandled exceptions raised if unsupported unit is passed...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -190,8 +190,15 @@ var describe = function(resp) {
 */
 Converter.prototype.describe = function (abbr) {
   var resp = Converter.prototype.getUnit(abbr);
+  var desc = null;
 
-  return describe(resp);
+  try {
+    desc = describe(resp);
+  } catch(err) {
+    this.throwUnsupportedUnitError(abbr);
+  }
+
+  return desc;
 };
 
 /**


### PR DESCRIPTION
… to `describe`

If no unit or an unsupported unit is passed to describe an exception should be raised...
and this is exactly what happens after this commit.

```
convert().describe('');
```
now returns `null` and `throwUnsupportedUnitError('')`