### PR TITLE
Enables users to add their own definitions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var convert
   , keys = require('lodash.keys')
   , each = require('lodash.foreach')
-  , measures = {
+  , initialDefinitions = {
       length: require('./definitions/length')
     , area: require('./definitions/area')
     , mass: require('./definitions/mass')
@@ -22,14 +22,43 @@ var convert
     , reactiveEnergy: require('./definitions/reactiveEnergy')
     , volumeFlowRate: require('./definitions/volumeFlowRate')
     }
-  , Converter;
+  , Converter
+  , definitions
+  , InvalidDefinitionError = require('./invalidDefinitionError');
 
 Converter = function (numerator, denominator) {
-  if(denominator)
+  if (!definitions) {
+    this.resetDefinitions();
+  }
+
+  if (denominator)
     this.val = numerator / denominator;
   else
     this.val = numerator;
 };
+
+Converter.prototype.resetDefinitions = function () {
+  definitions = {};
+  this.addDefinitions(initialDefinitions);
+
+  return this;
+};
+
+Converter.prototype.addDefinitions = function (newDefinitions) {
+  each(newDefinitions, function(definition, type) {
+    if (!isValidDefinition(definition)) {
+      throw new InvalidDefinitionError(type);
+    }
+
+    definitions[type] = definition;
+  });
+
+  return this;
+};
+
+function isValidDefinition(definition) {
+  return !!definition && !!definition._anchors;
+}
 
 /**
 * Lets the converter know the source unit abbreviation
@@ -99,11 +128,11 @@ Converter.prototype.to = function (to) {
   * transform here to provide the direct result
   */
   if(this.origin.system != this.destination.system) {
-    transform = measures[this.origin.measure]._anchors[this.origin.system].transform;
+    transform = definitions[this.origin.measure]._anchors[this.origin.system].transform;
     if (typeof transform === 'function') {
       return result = transform(result)
     }
-    result *= measures[this.origin.measure]._anchors[this.origin.system].ratio;
+    result *= definitions[this.origin.measure]._anchors[this.origin.system].ratio;
   }
 
   /**
@@ -155,7 +184,7 @@ Converter.prototype.toBest = function(options) {
 Converter.prototype.getUnit = function (abbr) {
   var found;
 
-  each(measures, function (systems, measure) {
+  each(definitions, function (systems, measure) {
     each(systems, function (units, system) {
       if(system == '_anchors')
         return false;
@@ -197,7 +226,7 @@ var describe = function(resp) {
 * An alias for getUnit
 */
 Converter.prototype.describe = function (abbr) {
-  var resp = Converter.prototype.getUnit(abbr);
+  var resp = this.getUnit(abbr);
   var desc = null;
 
   try {
@@ -215,7 +244,7 @@ Converter.prototype.describe = function (abbr) {
 Converter.prototype.list = function (measure) {
   var list = [];
 
-  each(measures, function (systems, testMeasure) {
+  each(definitions, function (systems, testMeasure) {
     if(measure && measure !== testMeasure)
       return;
 
@@ -240,7 +269,7 @@ Converter.prototype.list = function (measure) {
 Converter.prototype.throwUnsupportedUnitError = function (what) {
   var validUnits = [];
 
-  each(measures, function (systems, measure) {
+  each(definitions, function (systems, measure) {
     each(systems, function (units, system) {
       if(system == '_anchors')
         return false;
@@ -259,8 +288,8 @@ Converter.prototype.throwUnsupportedUnitError = function (what) {
 Converter.prototype.possibilities = function (measure) {
   var possibilities = [];
   if(!this.origin && !measure) {
-	  each(keys(measures), function (measure){
-		  each(measures[measure], function (units, system) {
+	  each(keys(definitions), function (measure){
+		  each(definitions[measure], function (units, system) {
 		    if(system == '_anchors')
 		      return false;
 
@@ -269,7 +298,7 @@ Converter.prototype.possibilities = function (measure) {
 	  });
   } else {
 	  measure = measure || this.origin.measure;
-	  each(measures[measure], function (units, system) {
+	  each(definitions[measure], function (units, system) {
 	    if(system == '_anchors')
 	      return false;
 
@@ -285,7 +314,7 @@ Converter.prototype.possibilities = function (measure) {
 * converted to.
 */
 Converter.prototype.measures = function () {
-  return keys(measures);
+  return keys(definitions);
 };
 
 convert = function (value) {

--- a/lib/invalidDefinitionError.js
+++ b/lib/invalidDefinitionError.js
@@ -1,0 +1,9 @@
+function InvalidDefinitionError(type, message) {
+  this.name = 'InvalidDefinitionError';
+  this.message = message || type + ' is not a valid definition.';
+  this.stack = (new Error()).stack;
+}
+InvalidDefinitionError.prototype = Object.create(Error.prototype);
+InvalidDefinitionError.prototype.constructor = InvalidDefinitionError;
+
+module.exports = InvalidDefinitionError;

--- a/test/addDefinition.js
+++ b/test/addDefinition.js
@@ -1,0 +1,46 @@
+var convert = require('../lib')
+  , assert = require('assert')
+  , tests = {}
+  , InvalidDefinitionError = require('../lib/InvalidDefinitionError');
+
+var validDefinition = {
+  metric: {
+    whatever: {
+      name: {
+        singular: 'something'
+      , plural: 'somethings'
+      }
+    , to_anchor: 1
+    }
+  }
+, _anchors: {
+    metric: {
+      unit: 'thing'
+    , ratio: 10
+    }
+  , imperial: {
+      unit: 'other thing'
+    , ratio: 1/10
+    }
+  }
+};
+
+tests['invalid definition throws'] = function () {
+  assert.throws(function () {
+    convert().addDefinitions({'INVALIDdefinition': {}});
+  }, InvalidDefinitionError );
+};
+
+tests['adding a definition'] = function () {
+  var converter = convert().addDefinitions({
+    'VALIDdefinition': validDefinition
+  , 'AnotherValid': validDefinition
+  });
+  console.log(convert().measures());
+  assert(convert().measures().indexOf('VALIDdefinition') > -1);
+  assert(convert().measures().indexOf('AnotherValid') > -1);
+  assert.deepEqual(convert().possibilities('VALIDdefinition'), ['whatever'])
+  assert.deepEqual(convert().possibilities('AnotherValid'), ['whatever'])
+};
+
+module.exports = tests;

--- a/test/measures.js
+++ b/test/measures.js
@@ -3,7 +3,7 @@ var convert = require('../lib')
   , tests = {};
 
 tests['measures'] = function () {
-  var actual = convert().measures()
+  var actual = convert().resetDefinitions().measures()
     , expected = [ 'length', 'area', 'mass', 'volume', 'each', 'temperature', 'time', 'digital', 'partsPer', 'speed', 'pressure', 'current', 'voltage', 'power', 'reactivePower', 'apparentPower', 'energy', 'reactiveEnergy', 'volumeFlowRate' ];
   assert.deepEqual(actual, expected);
 };


### PR DESCRIPTION
Adds a method `addDefinitions({measure: definition})` which enables users to add their own definitions as needed.