### PR TITLE
Fix square centimeters, krm, types

### DIFF
--- a/lib/definitions/area.js
+++ b/lib/definitions/area.js
@@ -11,8 +11,8 @@ metric = {
   }
 , cm2: {
     name: {
-      singular: 'Centimeter'
-    , plural: 'Centimeters'
+      singular: 'Square Centimeter'
+    , plural: 'Square Centimeters'
     }
   , to_anchor: 1/10000
   }

--- a/lib/definitions/volume.js
+++ b/lib/definitions/volume.js
@@ -69,8 +69,8 @@ metric = {
 // Swedish units
 , krm: {
   name: {
-    singular: 'Matsked'
-    , plural: 'Matskedar'
+    singular: 'Kryddmått'
+    , plural: 'Kryddmått'
   }
   , to_anchor: 1/1000
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,93 +1,107 @@
 declare module "convert-units" { 
-    type uDistance = "mm" | "cm" | "m" | "km" | "in" | "ft-us" | "ft" | "mi"; // Distance
-    type uArea = "mm2" | "cm2" | "m2" | "ha" | "km2" | "in2" | "ft2" | "ac" | "mi2"; // Area
-    type uMass = "mcg" | "mg" | "g" | "kg" | "oz" | "lb" | "mt" | "t" // Mass
-    type uVolume = "mm3" | "cm3" | "ml" | "l" | "kl" | "m3" | "km3" | "tsp" | "Tbs" | "in3" | "fl-oz" | "cup" | "pnt" | "qt" | "gal" | "ft3" | "yd3" // Volume
-    type uVolumeFlowRate = "mm3/s" | "cm3/s" | "ml/s" | "cl/s" | "dl/s" | "l/s" | "l/min" | "l/h" | "kl/s" | "kl/min" | "kl/h" | "m3/s" | "m3/min" | "m3/h" | "km3/s" | "tsp/s" | "Tbs/s" | "in3/s" | "in3/min" | "in3/h" | "fl-oz/s" | "fl-oz/min" | "fl-oz/h" | "cup/s" | "pnt/s" | "pnt/min" | "pnt/h" | "qt/s" | "gal/s" | "gal/min" | "gal/h"  | "ft3/s" | "ft3/min" | "ft3/h" | "yd3/s"  | "yd3/min" | "yd3/h"; // Volume Flow Rate
-    type uTemperature = "C" | "F" | "K" | "R"; // Temperature
-    type uTime = "ns" | "mu" | "ms" | "s" | "min" | "h" | "d" | "week" | "month" | "year"; // Time
-    type uFrequency = "Hz" | "mHz" | "kHz" | "MHz" | "GHz" | "THz" | "rpm" | "deg/s" | "rad/s"; // Frequency
-    type uSpeed = "m/s" | "km/h" | "m/h" | "knot" | "ft/s"; // Speed
-    type uPace = "s/m" | "min/km" | "s/ft" | "min/km"; // Pace
-    type uPressure = "Pa" | "hPa" | "kPa" | "MPa" | "bar" | "torr" | "psi" | "ksi"; // Pressure
-    type uDitgital = "b" | "Kb" | "Mb" | "Gb" | "Tb" | "B" | "KB" | "MB" | "GB" | "TB"; // Digital
-    type uIlluminance = "lx" | "ft-cd"; // Illumunance
-    type uPartsPer = "ppm" | "ppb" | "ppt" | "ppq"; // Parts-Per
-    type uVoltage = "V" | "mV" | "kV"; // Voltage
-    type uCurrent = "A" | "mA" | "kA"; // Current
-    type uPower = "W" | "mW" | "kM" | "MW" | "GW";
-    type uApparentPower = "VA" | "mVA" | "kVA" | "MVA" | "GVA"; // Apparent Power
-    type uReactivePower = "VAR" | "mVAR" | "kVAR" | "MVAR" | "GVAR"; // Reactive Power
-    type uEnergy = "Wh" | "mWh" | "kWh" | "MWh" | "GWh" | "J" | "kJ"; // Energy
-    type uReactiveEnergy = "VARh" | "mVARh" | "kVARh" | "MVARh" | "GVARH"; // Reactive Energy
-    type uAngle = "deg" | "rad" | "grad" | "arcmin" | "arcsec"; // Angle
+    export type Length = 'mm' | 'cm' | 'm' | 'km' | 'in' | 'yd' | 'ft-us' | 'ft' | 'mi';
+    export type Area = 'mm2' | 'cm2' | 'm2' | 'ha' | 'km2' | 'in2' | 'yd2' | 'ft2' | 'ac' | 'mi2';
+    export type Mass = 'mcg' | 'mg' | 'g' | 'kg' | 'mt' | 'oz' | 'lb' | 't';
+    export type Volume = 'mm3' | 'cm3' | 'ml' | 'cl' | 'dl' | 'l' | 'kl' | 'm3' | 'km3' | 'krm' | 'tsk' | 'msk' | 'kkp' | 'glas' | 'kanna' | 'tsp' | 'Tbs' | 'in3' | 'fl-oz' | 'cup' | 'pnt' | 'qt' | 'gal' | 'ft3' | 'yd3';
+    export type Each = 'ea' | 'dz';
+    export type Temperature = 'C' | 'K' | 'F' | 'R';
+    export type Time = 'ns' | 'mu' | 'ms' | 's' | 'min' | 'h' | 'd' | 'week' | 'month' | 'year';
+    export type Digital = 'b' | 'Kb' | 'Mb' | 'Gb' | 'Tb' | 'B' | 'KB' | 'MB' | 'GB' | 'TB';
+    export type PartsPer = 'ppm' | 'ppb' | 'ppt' | 'ppq';
+    export type Speed = 'm/s' | 'km/h' | 'm/h' | 'knot' | 'ft/s';
+    export type Pace = 'min/km' | 's/m' | 'min/mi' | 's/ft';
+    export type Pressure = 'Pa' | 'kPa' | 'MPa' | 'hPa' | 'bar' | 'torr' | 'psi' | 'ksi';
+    export type Current = 'A' | 'mA' | 'kA';
+    export type Voltage = 'V' | 'mV' | 'kV';
+    export type Power = 'W' | 'mW' | 'kW' | 'MW' | 'GW';
+    export type ReactivePower = 'VAR' | 'mVAR' | 'kVAR' | 'MVAR' | 'GVAR';
+    export type ApparentPower = 'VA' | 'mVA' | 'kVA' | 'MVA' | 'GVA';
+    export type Energy = 'Wh' | 'mWh' | 'kWh' | 'MWh' | 'GWh' | 'J' | 'kJ';
+    export type ReactiveEnergy = 'VARh' | 'mVARh' | 'kVARh' | 'MVARh' | 'GVARh';
+    export type VolumeFlowRate = 'mm3/s' | 'cm3/s' | 'ml/s' | 'cl/s' | 'dl/s' | 'l/s' | 'l/min' | 'l/h' | 'kl/s' | 'kl/min' | 'kl/h' | 'm3/s' | 'm3/min' | 'm3/h' | 'km3/s' | 'tsp/s' | 'Tbs/s' | 'in3/s' | 'in3/min' | 'in3/h' | 'fl-oz/s' | 'fl-oz/min' | 'fl-oz/h' | 'cup/s' | 'pnt/s' | 'pnt/min' | 'pnt/h' | 'qt/s' | 'gal/s' | 'gal/min' | 'gal/h' | 'ft3/s' | 'ft3/min' | 'ft3/h' | 'yd3/s' | 'yd3/min' | 'yd3/h';
+    export type Illuminance = 'lx' | 'ft-cd';
+    export type Frequency = 'mHz' | 'Hz' | 'kHz' | 'MHz' | 'GHz' | 'THz' | 'rpm' | 'deg/s' | 'rad/s';
+    export type Angle = 'rad' | 'deg' | 'grad' | 'arcmin' | 'arcsec';
 
 
-    type unit = uDistance 
-              | uArea 
-              | uMass 
-              | uVolume 
-              | uVolumeFlowRate 
-              | uTemperature 
-              | uTime 
-              | uFrequency 
-              | uSpeed 
-              | uPace 
-              | uPressure 
-              | uDitgital
-              | uIlluminance
-              | uPartsPer
-              | uVoltage
-              | uCurrent
-              | uPower
-              | uApparentPower
-              | uReactivePower
-              | uEnergy
-              | uReactiveEnergy
-              | uAngle;
+    export type Unit
+      = Length
+      | Area
+      | Mass
+      | Volume
+      | Each
+      | Temperature
+      | Time
+      | Digital
+      | PartsPer
+      | Speed
+      | Pace
+      | Pressure
+      | Current
+      | Voltage
+      | Power
+      | ReactivePower
+      | ApparentPower
+      | Energy
+      | ReactiveEnergy
+      | VolumeFlowRate
+      | Illuminance
+      | Frequency
+      | Angle;
 
-    type measure = "distance" 
-                 | "area" 
-                 | "mass" 
-                 | "volume" 
-                 | "volumeFlowRate" 
-                 | "temperature" 
-                 | "time" 
-                 | "frequency" 
-                 | "speed" 
-                 | "pace" 
-                 | "pressure" 
-                 | "ditgital"
-                 | "illuminance"
-                 | "partsPer"
-                 | "voltage"
-                 | "current"
-                 | "power"
-                 | "apparentPower"
-                 | "reactivePower"
-                 | "energy"
-                 | "reactiveEnergy"
-                 | "angle";
+    export type Measure
+      = "length"
+      | "area"
+      | "mass"
+      | "volume"
+      | "each"
+      | "temperature"
+      | "time"
+      | "digital"
+      | "partsPer"
+      | "speed"
+      | "pace"
+      | "pressure"
+      | "current"
+      | "voltage"
+      | "power"
+      | "reactivePower"
+      | "apparentPower"
+      | "energy"
+      | "reactiveEnergy"
+      | "volumeFlowRate"
+      | "illuminance"
+      | "frequency"
+      | "angle";
 
-    type system = "metric"
-                | "imperial"
-                | "bits"
-                | "bytes";
+    export type System
+      = "metric"
+      | "imperial"
+      | "bits"
+      | "bytes";
+
+    export interface UnitDetails {
+      abbr: Unit,
+      measure: Measure,
+      system: System,
+      singular: string,
+      plural: string
+    }
 
     class Convert {
         constructor(numerator: number, denominator: number);
-        from(from: unit): this; 
-        to(to: unit): number;
-        toBest(options?: { exclude?: unit[], cutOffNumber?: number }): { val: number, unit: string, singular: string, plural: string };
-        getUnit<T extends unit>(abbr: T): { abbr: T, measure: measure, system: system, unit: { name: { singular: string, plural: string }, to_anchor: number } };
-        describe<T extends unit>(abbr: T): { abbr: T, measure: measure, system: system, singular: string, plural: string };
-        list(measure?: measure): unit[];
+        from(from: Unit): this;
+        to(to: Unit): number;
+        toBest(options?: { exclude?: Unit[], cutOffNumber?: number }): { val: number, unit: string, singular: string, plural: string };
+        getUnit(abbr: Unit): { abbr: Unit, measure: Measure, system: System, unit: { name: { singular: string, plural: string }, to_anchor: number } };
+        describe(abbr: Unit): UnitDetails;
+        list(measure?: Measure): UnitDetails[];
         private throwUnsupportedUnitError(what: string): void;
-        possibilities(measure?: measure): unit[];
-        measures(): measure[];
+        possibilities(measure?: Measure): Unit[];
+        measures(): Measure[];
     }
 
-    function convert(value: number): Convert;
+    function convert(value?: number): Convert;
 
-    export = convert;
-}
+    export default convert;
+  }


### PR DESCRIPTION
- Area had Centimeters instead of Square Centimeters
- The Swedish unit krm was mapped to Matsked (tablespoons) instead of
  kryddmått (mL)
- Type definitions had several mistakes, including 'distance' instead of 'length',
  and some incorrectly typed methods. I didn't do a deep dive here; just the stuff
  I ran into.

I also exported and upcased the types.