### PR TITLE
Modified system-to-system conversion algorithm to allow for easier addition of new unit systems

### DIFF
--- a/lib/definitions/acceleration.js
+++ b/lib/definitions/acceleration.js
@@ -24,7 +24,7 @@ module.exports = {
   , _anchors: {
     metric: {
       unit: 'g-force'
-      , ratio: 1
+      , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/angle.js
+++ b/lib/definitions/angle.js
@@ -43,7 +43,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'deg'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/apparentPower.js
+++ b/lib/definitions/apparentPower.js
@@ -43,7 +43,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'VA'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/area.js
+++ b/lib/definitions/area.js
@@ -83,11 +83,11 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'm2'
-    , ratio: 10.7639
+    , to_anchor: 1
     }
   , imperial: {
       unit: 'ft2'
-    , ratio: 1/10.7639
+    , to_anchor: 1/10.7639
     }
   }
 };

--- a/lib/definitions/charge.js
+++ b/lib/definitions/charge.js
@@ -45,7 +45,7 @@ module.exports = {
   , _anchors: {
     metric: {
       unit: 'c'
-      , ratio: 1
+      , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/current.js
+++ b/lib/definitions/current.js
@@ -29,7 +29,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'A'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/digital.js
+++ b/lib/definitions/digital.js
@@ -83,11 +83,11 @@ module.exports = {
 , _anchors: {
     bits: {
       unit: 'b'
-    , ratio: 1/8
+    , to_anchor: 1/8
     }
   , bytes: {
       unit: 'B'
-    , ratio: 8
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/each.js
+++ b/lib/definitions/each.js
@@ -24,7 +24,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'ea'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/energy.js
+++ b/lib/definitions/energy.js
@@ -57,7 +57,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'J'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/force.js
+++ b/lib/definitions/force.js
@@ -31,7 +31,7 @@ module.exports = {
   , _anchors: {
     metric: {
       unit: 'N'
-      , ratio: 1
+      , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/frequency.js
+++ b/lib/definitions/frequency.js
@@ -72,7 +72,7 @@ module.exports = {
 , _anchors: {
     frequency: {
       unit: 'hz'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/illuminance.js
+++ b/lib/definitions/illuminance.js
@@ -27,11 +27,11 @@ module.exports = {
   _anchors: {
     metric: {
       unit: 'lx',
-      ratio: 1/10.76391
+      to_anchor: 1
     },
     imperial: {
       unit: 'ft-cd',      
-	  ratio: 10.76391
+	  to_anchor: 10.76391
     }
   }
 };

--- a/lib/definitions/length.js
+++ b/lib/definitions/length.js
@@ -90,11 +90,11 @@ module.exports = {
   _anchors: {
     metric: {
       unit: 'm',
-      ratio: 3.28084
+      to_anchor: 1
     },
     imperial: {
       unit: 'ft',
-      ratio: 1/3.28084
+      to_anchor: 1/3.28084
     }
   }
 };

--- a/lib/definitions/mass.js
+++ b/lib/definitions/mass.js
@@ -68,11 +68,11 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'g'
-    , ratio: 1/453.592
+    , to_anchor: 1
     }
   , imperial: {
       unit: 'lb'
-    , ratio: 453.592
+    , to_anchor: 453.592
     }
   }
 };

--- a/lib/definitions/pace.js
+++ b/lib/definitions/pace.js
@@ -41,11 +41,11 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 's/m'
-    , ratio: 0.3048
+    , to_anchor: 1
     }
   , imperial: {
       unit: 's/ft'
-    , ratio: 1/0.3048
+    , to_anchor: 1/0.3048
     }
   }
 };

--- a/lib/definitions/partsPer.js
+++ b/lib/definitions/partsPer.js
@@ -38,7 +38,7 @@ module.exports = {
   , _anchors: {
     metric: {
       unit: 'ppm'
-      , ratio: .000001
+      , to_anchor: .000001
     }
   }
 };

--- a/lib/definitions/power.js
+++ b/lib/definitions/power.js
@@ -43,7 +43,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'W'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/pressure.js
+++ b/lib/definitions/pressure.js
@@ -69,11 +69,11 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'kPa'
-    , ratio: 0.00014503768078
+    , to_anchor: 1
     }
   , imperial: {
       unit: 'psi'
-    , ratio: 1/0.00014503768078
+    , to_anchor: 1/0.00014503768078
     }
   }
 };

--- a/lib/definitions/reactiveEnergy.js
+++ b/lib/definitions/reactiveEnergy.js
@@ -43,7 +43,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'VARh'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/reactivePower.js
+++ b/lib/definitions/reactivePower.js
@@ -43,7 +43,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'VAR'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/speed.js
+++ b/lib/definitions/speed.js
@@ -48,11 +48,11 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'km/h'
-    , ratio: 1/1.609344
+    , to_anchor: 1
     }
   , imperial: {
       unit: 'm/h'
-    , ratio: 1.609344
+    , to_anchor: 1.609344
     }
   }
 };

--- a/lib/definitions/temperature.js
+++ b/lib/definitions/temperature.js
@@ -44,11 +44,12 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'C'
-    , transform: function (C) { return C / (5/9) + 32 }
+    , to_anchor: 1
     }
   , imperial: {
       unit: 'F'
-    , transform: function (F) { return (F - 32) * (5/9) }
+    , transformToAnchor: function (F) { return (F - 32) * (5/9) }
+    , transformFromAnchor: function (C) { return C / (5/9) + 32 }
     }
   }
 };

--- a/lib/definitions/time.js
+++ b/lib/definitions/time.js
@@ -80,7 +80,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 's'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/voltage.js
+++ b/lib/definitions/voltage.js
@@ -29,7 +29,7 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'V'
-    , ratio: 1
+    , to_anchor: 1
     }
   }
 };

--- a/lib/definitions/volume.js
+++ b/lib/definitions/volume.js
@@ -190,11 +190,11 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'l'
-    , ratio: 33.8140226
+    , to_anchor: 1
     }
   , imperial: {
       unit: 'fl-oz'
-    , ratio: 1/33.8140226
+    , to_anchor: 1/33.8140226
     }
   }
 };

--- a/lib/definitions/volumeFlowRate.js
+++ b/lib/definitions/volumeFlowRate.js
@@ -272,11 +272,11 @@ module.exports = {
 , _anchors: {
     metric: {
       unit: 'l/s'
-    , ratio: 33.8140227
+    , to_anchor: 1
     }
   , imperial: {
       unit: 'fl-oz/s'
-    , ratio: 1/33.8140227
+    , to_anchor: 1/33.8140227
     }
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,20 +101,30 @@ Converter.prototype.to = function (to) {
   * transform here to provide the direct result
   */
   if(this.origin.system != this.destination.system) {
-    transform = measures[this.origin.measure]._anchors[this.origin.system].transform;
+    transform = measures[this.origin.measure]._anchors[this.origin.system].transformToAnchor;
     if (typeof transform === 'function') {
       result = transform(result)
     }
     else {
       /**
-      * Convert from the source system to the anchor system
+      * Check if the unit needs to be piped through a tranform function to convert
+      * to the destination system
       */
-      result *= measures[this.origin.measure]._anchors[this.origin.system].to_anchor;
+      transform = measures[this.destination.measure]._anchors[this.destination.system].transformFromAnchor;
+      if (typeof transform === 'function') {
+        result = transform(result)
+      }
+      else {
+        /**
+        * Convert from the source system to the anchor system
+        */
+        result *= measures[this.origin.measure]._anchors[this.origin.system].to_anchor;
 
-      /**
-      * Convert from the anchor sytem to the destination system
-      */
-      result /= measures[this.destination.measure]._anchors[this.destination.system].to_anchor;
+        /**
+        * Convert from the anchor sytem to the destination system
+        */
+        result /= measures[this.destination.measure]._anchors[this.destination.system].to_anchor;
+      }
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,15 @@ Converter.prototype.to = function (to) {
       result = transform(result)
     }
     else {
-      result *= measures[this.origin.measure]._anchors[this.origin.system].ratio;
+      /**
+      * Convert from the source system to the anchor system
+      */
+      result *= measures[this.origin.measure]._anchors[this.origin.system].to_anchor;
+
+      /**
+      * Convert from the anchor sytem to the destination system
+      */
+      result /= measures[this.destination.measure]._anchors[this.destination.system].to_anchor;
     }
   }
 


### PR DESCRIPTION
I figured that since a 'to-base-unit' algorithm worked just fine for converting units within a system, we can also use a 'to-base-system' algorithm to convert units from one system to another.
The process works exactly the same as the conversion of a unit to its anchor value within its own system.

Since the Metric unit system is by far the most popular, widespread, and easy to use, I figured that it would be the best candidate for the anchor system.

