### PR TITLE
Two new units of length (pt and pc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ convert().list('mass')
 Supported Units
 ---------------
 ### Length
+* pt
+* pc
 * mm
 * cm
 * m

--- a/lib/definitions/length.js
+++ b/lib/definitions/length.js
@@ -33,6 +33,20 @@ metric = {
 };
 
 imperial = {
+  pt: {
+    name: {
+      singular: 'Point',
+      plural: 'Points'
+    },
+    to_anchor: 1/864
+  },
+  pc: {
+    name: {
+      singular: 'Pica',
+      plural: 'Picas'
+    },
+    to_anchor: 1/72
+  },
   'in': {
     name: {
       singular: 'Inch',


### PR DESCRIPTION
Added two new units of length normally used in typography / type sizes, based on the PostScript definition of pica/point.
* Point (pt) which is 1/72 of an inch. *(1/864 of anchor)*
* Pica (pc) which is 1/6 of an inch. *(1/72 of anchor)*