### PR TITLE
force: lbf is an imperial unit, added klbf

### DIFF
--- a/lib/definitions/force.js
+++ b/lib/definitions/force.js
@@ -1,38 +1,52 @@
 var metric
-  , imperial;
+    , imperial;
 
 metric = {
-  N: {
-    name: {
-      singular: 'Newton'
-      , plural: 'Newtons'
+    N: {
+        name: {
+            singular: 'Newton'
+            , plural: 'Newtons'
+        }
+        , to_anchor: 1
     }
-    , to_anchor: 1
-  }
-  , kN: {
-    name: {
-      singular: 'Kilonewton'
-      , plural: 'Kilonewtons'
+    , kN: {
+        name: {
+            singular: 'Kilonewton'
+            , plural: 'Kilonewtons'
+        }
+        , to_anchor: 1000
     }
-    , to_anchor: 1000
-  }
-  , lbf: {
-    name: {
-      singular: 'Pound-force'
-      , plural: 'Pound-forces'
+};
+
+imperial = {
+    lbf: {
+        name: {
+            singular: 'Pound-force'
+            , plural: 'Pound-forces'
+        }
+        , to_anchor: 1
+    },
+    klbf: {
+        name: {
+            singular: 'Kilopound-force'
+            , plural: 'Kilopound-forces'
+        }
+        , to_anchor: 1000
     }
-    , to_anchor: 4.44822
-  }
 };
 
 module.exports = {
-  metric: metric
-  , imperial: {}
-  , _anchors: {
-    metric: {
-      unit: 'N'
-      , ratio: 1
+    metric: metric
+    , imperial: imperial
+    , _anchors: {
+        metric: {
+            unit: 'N'
+            , ratio: 1/4.44822
+        },
+        imperial: {
+            unit: 'lbf'
+            , ratio: 4.44822
+        }
     }
-  }
 };
 

--- a/test/force.js
+++ b/test/force.js
@@ -2,7 +2,7 @@ var convert = require('../lib')
   , assert = require('assert')
   , tests = {};
 
-var EPSILON = 0.000001
+var EPSILON = 0.000001;
 
 tests['N to kN'] = function () {
   assert.strictEqual(convert(1).from('N').to('kN') , 1/1000);
@@ -14,6 +14,10 @@ tests['kN to N'] = function () {
 
 tests['N to lbf'] = function () {
   assert.strictEqual(true, Math.abs(convert(1).from('N').to('lbf') - 0.224809) < EPSILON);
+};
+
+tests['kN to klbf'] = function () {
+  assert.strictEqual(true, Math.abs(convert(1).from('kN').to('klbf') - 0.224809) < EPSILON);
 };
 
 tests['lbf to N'] = function () {

--- a/test/possibilities.js
+++ b/test/possibilities.js
@@ -162,7 +162,7 @@ tests['charge possibilities'] = function() {
 
 tests['force possibilities'] = function() {
   var actual = convert().possibilities('force')
-    , expected = [ 'N', 'kN', 'lbf'];
+    , expected = [ 'N', 'kN', 'lbf', 'klbf'];
   assert.deepEqual(actual.sort(), expected.sort());
 };
 
@@ -261,6 +261,7 @@ tests['all possibilities'] = function () {
       , 'kJ'
       , 'kN'
       , 'kl'
+      , 'klbf'
       , 'kl/h'
       , 'kl/min'
       , 'kl/s'


### PR DESCRIPTION
Pound-force was previously handled as a metric unit. Kilopound-force was missing. I have updated tests accordingly. Also, can you please update the npm package which is missing force and several other useful commits?