### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+**/__tests__
+coverage
+.eslintrc.js
+.github/**/*
+.prettierignore
+.prettierrc.json


### PR DESCRIPTION
- Add .npmignore which will exclude all dot files and tests from the
package published to npm

Note: this can be tested with `npm pack --dry-run` in the project root
directory

Fixes #184