### PR TITLE
Fix Error TS4023 and eslint warnings

### DIFF
--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -146,3 +146,15 @@ test('post-cut off number', () => {
     };
   expect(actual).toEqual(expected);
 });
+
+test('return null if all possible units are excluded', () => {
+  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
+    length,
+  });
+  const convertLenght = convert(10);
+  const actual = convertLenght
+      .from('km')
+      .toBest({ exclude: convertLenght.possibilities() }),
+    expected = null;
+  expect(actual).toEqual(expected);
+});

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -38,10 +38,17 @@ export interface Measure<TSystems extends string, TUnits extends string> {
   anchors?: Partial<Record<TSystems, Partial<Record<TSystems, Anchor>>>>;
 }
 
+export interface BestResult {
+  val: number;
+  unit: string;
+  singular: string;
+  plural: string;
+}
+
 /**
  * Represents a conversion path
  */
-class Converter<
+export class Converter<
   TMeasures extends string,
   TSystems extends string,
   TUnits extends string
@@ -180,7 +187,10 @@ class Converter<
   /**
    * Converts the unit to the best available unit.
    */
-  toBest(options?: { exclude?: TUnits[]; cutOffNumber?: number }) {
+  toBest(options?: {
+    exclude?: TUnits[];
+    cutOffNumber?: number;
+  }): BestResult | null {
     if (this.origin == null)
       throw new Error('.toBest must be called after .from');
 
@@ -349,7 +359,7 @@ class Converter<
    * Returns the abbreviated measures that the value can be
    * converted to.
    */
-  possibilities(forMeasure?: TMeasures) {
+  possibilities(forMeasure?: TMeasures): TUnits[] {
     let possibilities: TUnits[] = [];
     let list_measures: TMeasures[] = [];
 
@@ -379,8 +389,8 @@ class Converter<
    * Returns the abbreviated measures that the value can be
    * converted to.
    */
-  measures() {
-    return Object.keys(this.measureData);
+  measures(): TMeasures[] {
+    return Object.keys(this.measureData) as TMeasures[];
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
-import configMeasurements from './convert';
+import configMeasurements, { Converter } from './convert';
 import allMeasures from './definitions';
 export default configMeasurements;
 export type {
   Anchor,
+  BestResult,
   Conversion,
   Measure,
   Unit,
   UnitDescription,
 } from './convert';
 export * from './definitions';
-export { allMeasures };
+export { allMeasures, Converter };


### PR DESCRIPTION
- Fix typescript error TS4023 is to export the Converter class. This error
happens because typescript can't determine it's shape.
- Fix eslint warnings
- Add test case where toBest can actually return null

Fix for #178 