### PR TITLE
feat: `system` option for `toBest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ convert(900).from('mm').toBest({ cutOffNumber: 10 });
 
 convert(1000).from('mm').toBest({ cutOffNumber: 10 });
 // { val: 100, unit: 'cm', plural: 'Centimeters' } (the smallest unit with a value equal to or above 10)
+
+// by default the system of the origin is used, the `system` option overwrites this behaviour
+convert(254).from('mm').toBest({ system: 'imperial' }); // ('mm' is metric)
+// { val: 10, unit: 'in', plural: 'Inches' }            // ('in' is imperial)
 ```
 
 You can get a list of the measures available to the current instance with `.measures`
@@ -688,4 +692,3 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-

--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -79,6 +79,36 @@ test('excludes measurements', () => {
   expect(actual).toEqual(expected);
 });
 
+test('should convert to the chosen system', () => {
+  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
+    length,
+  });
+  const actual = convert(1200000).from('mm').toBest({ system: 'imperial' }),
+    expected = {
+      val: 656.168,
+      unit: 'fathom',
+      singular: 'Fathom',
+      plural: 'Fathoms',
+    };
+  expect(actual).toEqual(expected);
+});
+
+test('should exlude values and convert to the chosen system', () => {
+  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
+    length,
+  });
+  const actual = convert(1200000)
+      .from('mm')
+      .toBest({ exclude: ['fathom'], system: 'imperial' }),
+    expected = {
+      val: 1312.336,
+      unit: 'yd',
+      singular: 'Yard',
+      plural: 'Yards',
+    };
+  expect(actual).toEqual(expected);
+});
+
 test('does not break when excluding from measurement', () => {
   const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
     length,

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -190,15 +190,18 @@ export class Converter<
   toBest(options?: {
     exclude?: TUnits[];
     cutOffNumber?: number;
+    system?: TSystems;
   }): BestResult | null {
     if (this.origin == null)
       throw new Error('.toBest must be called after .from');
 
     let exclude: TUnits[] = [];
     let cutOffNumber = 1;
+    let system = this.origin.system;
     if (typeof options === 'object') {
       exclude = options.exclude ?? [];
       cutOffNumber = options.cutOffNumber ?? 1;
+      system = options.system ?? this.origin.system;
     }
 
     let best = null;
@@ -211,7 +214,7 @@ export class Converter<
       const unit = this.describe(possibility);
       const isIncluded = exclude.indexOf(possibility) === -1;
 
-      if (isIncluded && unit.system === this.origin.system) {
+      if (isIncluded && unit.system === system) {
         const result = this.to(possibility);
         if (best == null || (result >= cutOffNumber && result < best.val)) {
           best = {


### PR DESCRIPTION
This MR adds a `system` option to the `toBest` function.
The `system` option overwrites the default behaviour of using the system of the origin.

The following example will provide the best **metric** unit or `null`: 
```js
convert(1000).from('mm').toBest()
```

The following example will provide the best **imperial** unit or `null`: 
```js
convert(1000).from('mm').toBest({system: 'imperial'})
```

### Why?
Technically the same can be achieved by doing:
```js
const imperialValue = convert(1000).from('mm').to('in');
convert(imperialValue).from('in').toBest();
```
However, this requires the user to find a unit of the desired system ('mm' -> 'in', 'ml' -> 'gal', ...). When the origin unit is an unknown for the user this becomes combersome.