### PR TITLE
Adds a couple of imperial aviation units

### DIFF
--- a/src/__tests__/possibilities.test.ts
+++ b/src/__tests__/possibilities.test.ts
@@ -323,7 +323,7 @@ test('pressure possibilities', () => {
     pressure,
   });
   const actual = convert().possibilities('pressure'),
-    expected = ['Pa', 'kPa', 'MPa', 'hPa', 'bar', 'torr', 'psi', 'ksi'];
+    expected = ['Pa', 'kPa', 'MPa', 'hPa', 'bar', 'torr', 'psi', 'ksi', 'inHg'];
   expect(actual.sort()).toEqual(expected.sort());
 });
 
@@ -332,7 +332,7 @@ test('speed possibilities', () => {
     speed,
   });
   const actual = convert().possibilities('speed'),
-    expected = ['m/s', 'km/h', 'mph', 'knot', 'ft/s'];
+    expected = ['m/s', 'km/h', 'mph', 'knot', 'ft/s', 'ft/min'];
   expect(actual.sort()).toEqual(expected.sort());
 });
 
@@ -561,6 +561,7 @@ test('all possibilities', () => {
       'fathom',
       'ft-cd',
       'ft-lb/s',
+      'ft/min',
       'ft/s',
       'ft2',
       'ft3',
@@ -592,6 +593,7 @@ test('all possibilities', () => {
       'in3/h',
       'in3/min',
       'in3/s',
+      'inHg',
       'J',
       'kA',
       'kPa',

--- a/src/definitions/__tests__/pressure.test.ts
+++ b/src/definitions/__tests__/pressure.test.ts
@@ -104,3 +104,47 @@ test('psi to hPa', () => {
   });
   expect(convert(10).from('psi').to('hPa')).toBeCloseTo(689.47573);
 });
+
+test('psi to inHg', () => {
+  const convert = configureMeasurements<
+    'pressure',
+    PressureSystems,
+    PressureUnits
+  >({
+    pressure,
+  });
+  expect(convert(1).from('psi').to('inHg')).toBeCloseTo(2.03602);
+});
+
+test('inHg to psi', () => {
+  const convert = configureMeasurements<
+    'pressure',
+    PressureSystems,
+    PressureUnits
+  >({
+    pressure,
+  });
+  expect(convert(1).from('inHg').to('psi')).toBeCloseTo(0.491154);
+});
+
+test('inHg to Pa', () => {
+  const convert = configureMeasurements<
+    'pressure',
+    PressureSystems,
+    PressureUnits
+  >({
+    pressure,
+  });
+  expect(convert(1).from('inHg').to('Pa')).toBeCloseTo(3386.389);
+});
+
+test('Pa to inHg', () => {
+  const convert = configureMeasurements<
+    'pressure',
+    PressureSystems,
+    PressureUnits
+  >({
+    pressure,
+  });
+  expect(convert(1013.25).from('hPa').to('inHg')).toBeCloseTo(29.92);
+});

--- a/src/definitions/__tests__/speed.test.ts
+++ b/src/definitions/__tests__/speed.test.ts
@@ -49,3 +49,17 @@ test('mph to km/h', () => {
   });
   expect(convert(12).from('mph').to('km/h')).toBeCloseTo(19.3121);
 });
+
+test('ft/s to ft/min', () => {
+  const convert = configureMeasurements<'speed', SpeedSystems, SpeedUnits>({
+    speed,
+  });
+  expect(convert(1).from('ft/s').to('ft/min')).toBeCloseTo(60);
+});
+
+test('m/s to ft/min', () => {
+  const convert = configureMeasurements<'speed', SpeedSystems, SpeedUnits>({
+    speed,
+  });
+  expect(convert(1).from('m/s').to('ft/min')).toBeCloseTo(196.85);
+});

--- a/src/definitions/pressure.ts
+++ b/src/definitions/pressure.ts
@@ -3,7 +3,7 @@ export type PressureUnits = PressureMetricUnits | PressureImperialUnits;
 export type PressureSystems = 'metric' | 'imperial';
 
 export type PressureMetricUnits = 'Pa' | 'kPa' | 'MPa' | 'hPa' | 'bar' | 'torr';
-export type PressureImperialUnits = 'psi' | 'ksi';
+export type PressureImperialUnits = 'psi' | 'ksi' | 'inHg';
 
 const metric: Record<PressureMetricUnits, Unit> = {
   Pa: {
@@ -64,6 +64,13 @@ const imperial: Record<PressureImperialUnits, Unit> = {
       plural: 'kilopound per square inch',
     },
     to_anchor: 1,
+  },
+  inHg: {
+    name: {
+      singular: 'inch of mercury',
+      plural: 'inches of mercury',
+    },
+    to_anchor: 0.000491154,
   },
 };
 

--- a/src/definitions/pressure.ts
+++ b/src/definitions/pressure.ts
@@ -67,8 +67,8 @@ const imperial: Record<PressureImperialUnits, Unit> = {
   },
   inHg: {
     name: {
-      singular: 'inch of mercury',
-      plural: 'inches of mercury',
+      singular: 'Inch of mercury',
+      plural: 'Inches of mercury',
     },
     to_anchor: 0.000491154,
   },

--- a/src/definitions/speed.ts
+++ b/src/definitions/speed.ts
@@ -3,7 +3,7 @@ export type SpeedUnits = SpeedMetricUnits | SpeedImperialUnits;
 export type SpeedSystems = 'metric' | 'imperial';
 
 export type SpeedMetricUnits = 'm/s' | 'km/h';
-export type SpeedImperialUnits = 'mph' | 'knot' | 'ft/s';
+export type SpeedImperialUnits = 'mph' | 'knot' | 'ft/s' | 'ft/min';
 
 const metric: Record<SpeedMetricUnits, Unit> = {
   'm/s': {
@@ -44,6 +44,14 @@ const imperial: Record<SpeedImperialUnits, Unit> = {
     },
     to_anchor: 0.681818,
   },
+  'ft/min': {
+    name: {
+      singular: 'Foot per minute',
+      plural: 'Feet per minute',
+    },
+    to_anchor: 0.0113636,
+  },
+
 };
 
 const measure: Measure<SpeedSystems, SpeedUnits> = {

--- a/src/definitions/speed.ts
+++ b/src/definitions/speed.ts
@@ -51,7 +51,6 @@ const imperial: Record<SpeedImperialUnits, Unit> = {
     },
     to_anchor: 0.0113636,
   },
-
 };
 
 const measure: Measure<SpeedSystems, SpeedUnits> = {


### PR DESCRIPTION
Adds inches of mercury (inHg) at standard temp and feet per minute (ft/min), with tests.

Relates to issue https://github.com/convert-units/convert-units/issues/87