### PR TITLE
Fix `toBest` returning first result even if it's less than the `cutOffNumber`

### DIFF
--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -188,3 +188,47 @@ test('return null if all possible units are excluded', () => {
     expected = null;
   expect(actual).toEqual(expected);
 });
+
+test('no good options available should produce the same value and unit', () => {
+  type TestMeasureSystems = 'test';
+  type TestMeasureUnits = 'a' | 'al' | 'axl';
+  const convert = configureMeasurements<'testmeasure', TestMeasureSystems, TestMeasureUnits>({
+    testmeasure: {
+      systems: {
+        test: {
+          a: {
+            name: {
+              singular: 'a',
+              plural: 'as',
+            },
+            to_anchor: 1,
+          },
+          al: {
+            name: {
+              singular: 'al',
+              plural: 'als',
+            },
+            to_anchor: 1 / 1000,
+          },
+          axl: {
+            name: {
+              singular: 'axl',
+              plural: 'axls',
+            },
+            to_anchor: 1 / 1000000,
+          },
+        }
+      }
+    },
+  });
+  const actual = convert(10)
+      .from('al')
+      .toBest(),
+    expected = {
+      val: 10,
+      unit: 'al',
+      singular: 'al',
+      plural: 'als',
+    };
+  expect(actual).toEqual(expected);
+});

--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -189,7 +189,7 @@ test('return null if all possible units are excluded', () => {
   expect(actual).toEqual(expected);
 });
 
-test('no good options available should produce the same value and unit', () => {
+test('Make sure that the first unit tested cannot become the best value if it is less than the cutOffNumber', () => {
   type TestMeasureSystems = 'test';
   type TestMeasureUnits = 'a' | 'al' | 'axl';
   const convert = configureMeasurements<'testmeasure', TestMeasureSystems, TestMeasureUnits>({

--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -192,7 +192,11 @@ test('return null if all possible units are excluded', () => {
 test('Make sure that the first unit tested cannot become the best value if it is less than the cutOffNumber', () => {
   type TestMeasureSystems = 'test';
   type TestMeasureUnits = 'a' | 'al' | 'axl';
-  const convert = configureMeasurements<'testmeasure', TestMeasureSystems, TestMeasureUnits>({
+  const convert = configureMeasurements<
+    'testmeasure',
+    TestMeasureSystems,
+    TestMeasureUnits
+  >({
     testmeasure: {
       systems: {
         test: {
@@ -217,13 +221,11 @@ test('Make sure that the first unit tested cannot become the best value if it is
             },
             to_anchor: 1 / 1000000,
           },
-        }
-      }
+        },
+      },
     },
   });
-  const actual = convert(10)
-      .from('al')
-      .toBest(),
+  const actual = convert(10).from('al').toBest(),
     expected = {
       val: 10,
       unit: 'al',

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -216,6 +216,9 @@ export class Converter<
 
       if (isIncluded && unit.system === system) {
         const result = this.to(possibility);
+        if (result < cutOffNumber) {
+          continue;
+        }
         if (best == null || (result >= cutOffNumber && result < best.val)) {
           best = {
             val: result,


### PR DESCRIPTION
Fixes #219