### PR TITLE
Fix typo uppercase in "PartsPerSIUnits" type

### DIFF
--- a/src/definitions/partsPer.ts
+++ b/src/definitions/partsPer.ts
@@ -1,5 +1,5 @@
 import { Measure, Unit } from './../index';
-export type PartsPerUnits = PArtsPerSIUnits;
+export type PartsPerUnits = PartsPerSIUnits;
 export type PartsPerSystems = 'SI';
 
 export type PartsPerSIUnits = 'ppm' | 'ppb' | 'ppt' | 'ppq';

--- a/src/definitions/partsPer.ts
+++ b/src/definitions/partsPer.ts
@@ -2,9 +2,9 @@ import { Measure, Unit } from './../index';
 export type PartsPerUnits = PArtsPerSIUnits;
 export type PartsPerSystems = 'SI';
 
-export type PArtsPerSIUnits = 'ppm' | 'ppb' | 'ppt' | 'ppq';
+export type PartsPerSIUnits = 'ppm' | 'ppb' | 'ppt' | 'ppq';
 
-const SI: Record<PArtsPerSIUnits, Unit> = {
+const SI: Record<PartsPerSIUnits, Unit> = {
   ppm: {
     name: {
       singular: 'Part-per Million',


### PR DESCRIPTION
Was `PArtsPerSIUnits`, now `PartsPerSIUnits`.

Not sure where else it may need to be updated.