### PR TITLE
feat: add mass flow rate conversions

### DIFF
--- a/src/__tests__/measures.test.ts
+++ b/src/__tests__/measures.test.ts
@@ -27,6 +27,7 @@ test('measures', () => {
       'illuminance',
       'length',
       'mass',
+      'massFlowRate',
       'pace',
       'partsPer',
       'pieces',

--- a/src/__tests__/possibilities.test.ts
+++ b/src/__tests__/possibilities.test.ts
@@ -29,6 +29,10 @@ import illuminance, {
 } from '../definitions/illuminance';
 import length, { LengthSystems, LengthUnits } from '../definitions/length';
 import mass, { MassSystems, MassUnits } from '../definitions/mass';
+import massFlowRate, {
+  MassFlowRateSystems,
+  MassFlowRateUnits,
+} from '../definitions/massFlowRate';
 import pace, { PaceSystems, PaceUnits } from '../definitions/pace';
 import partsPer, {
   PartsPerSystems,
@@ -145,6 +149,19 @@ test('mass possibilities', () => {
   });
   const actual = convert().possibilities('mass'),
     expected = ['mcg', 'mg', 'g', 'kg', 'mt', 'oz', 'lb', 't'];
+  expect(actual.sort()).toEqual(expected.sort());
+});
+
+test('mass flow rate possibilities', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  const actual = convert().possibilities('massFlowRate'),
+    expected = ['kg/h', 'kg/s', 'lb/h', 'lb/s', 'mt/h'];
   expect(actual.sort()).toEqual(expected.sort());
 });
 
@@ -606,12 +623,16 @@ test('all possibilities', () => {
       'kg',
       'kkp',
       'kJ',
+      'lb/h',
+      'lb/s',
       'MJ',
       'GJ',
       'kN',
       'kl',
       'Ml',
       'Gl',
+      'kg/h',
+      'kg/s',
       'kl/h',
       'kl/min',
       'kl/s',
@@ -666,6 +687,7 @@ test('all possibilities', () => {
       'ms',
       'msk',
       'mt',
+      'mt/h',
       'mu',
       'nC',
       'nm',

--- a/src/definitions/__tests__/massFlowRate.test.ts
+++ b/src/definitions/__tests__/massFlowRate.test.ts
@@ -1,0 +1,116 @@
+import configureMeasurements from '../..';
+
+import massFlowRate, {
+  MassFlowRateSystems,
+  MassFlowRateUnits,
+} from '../massFlowRate';
+
+test('kg/s to kg/h', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('kg/s').to('kg/h')).toBe(3600);
+});
+
+test('lb/s to lb/h', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('lb/s').to('lb/h')).toBe(3600);
+});
+
+test('kg/s to lb/s', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('kg/s').to('lb/s')).toBeCloseTo(2.204623);
+});
+
+test('lb/s to kg/s', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('lb/s').to('kg/s')).toBeCloseTo(0.453592);
+});
+
+test('kg/h to lb/h', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('kg/h').to('lb/h')).toBeCloseTo(2.204623);
+});
+
+test('lb/h to kg/h', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('lb/h').to('kg/h')).toBeCloseTo(0.453592);
+});
+
+test('kg/h to t/h', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('kg/h').to('mt/h')).toBe(0.001);
+});
+
+test('mt/h to kg/h', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('mt/h').to('kg/h')).toBe(1000);
+});
+
+test('lb/h to t/h', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('lb/h').to('mt/h')).toBeCloseTo(0.0004535924);
+});
+
+test('mt/h to lb/h', () => {
+  const convert = configureMeasurements<
+    'massFlowRate',
+    MassFlowRateSystems,
+    MassFlowRateUnits
+  >({
+    massFlowRate,
+  });
+  expect(convert(1).from('mt/h').to('lb/h')).toBeCloseTo(2204.622622);
+});

--- a/src/definitions/index.ts
+++ b/src/definitions/index.ts
@@ -22,6 +22,10 @@ import illuminance, {
 } from './illuminance';
 import length, { LengthSystems, LengthUnits } from './length';
 import mass, { MassSystems, MassUnits } from './mass';
+import massFlowRate, {
+  MassFlowRateSystems,
+  MassFlowRateUnits,
+} from './massFlowRate';
 import pace, { PaceSystems, PaceUnits } from './pace';
 import partsPer, { PartsPerSystems, PartsPerUnits } from './partsPer';
 import pieces, { PiecesSystems, PiecesUnits } from './pieces';
@@ -63,6 +67,7 @@ export type AllMeasuresSystems =
   | IlluminanceSystems
   | LengthSystems
   | MassSystems
+  | MassFlowRateSystems
   | PaceSystems
   | PartsPerSystems
   | PiecesSystems
@@ -92,6 +97,7 @@ export type AllMeasuresUnits =
   | IlluminanceUnits
   | LengthUnits
   | MassUnits
+  | MassFlowRateUnits
   | PaceUnits
   | PartsPerUnits
   | PiecesUnits
@@ -121,6 +127,7 @@ export type AllMeasures =
   | 'illuminance'
   | 'length'
   | 'mass'
+  | 'massFlowRate'
   | 'pace'
   | 'partsPer'
   | 'pieces'
@@ -153,6 +160,7 @@ const allMeasures: Record<
   illuminance,
   length,
   mass,
+  massFlowRate,
   pace,
   partsPer,
   pieces,
@@ -240,6 +248,7 @@ export {
   illuminance,
   length,
   mass,
+  massFlowRate,
   pace,
   partsPer,
   pieces,

--- a/src/definitions/massFlowRate.ts
+++ b/src/definitions/massFlowRate.ts
@@ -1,0 +1,72 @@
+import { Measure, Unit } from './../index';
+
+export type MassFlowRateUnits =
+  | MassFlowRateMetricUnits
+  | MassFlowRateImperialUnits;
+
+export type MassFlowRateSystems = 'metric' | 'imperial';
+
+export type MassFlowRateMetricUnits = 'kg/s' | 'kg/h' | 'mt/h';
+export type MassFlowRateImperialUnits = 'lb/s' | 'lb/h';
+
+const metric: Record<MassFlowRateMetricUnits, Unit> = {
+  'kg/s': {
+    name: {
+      singular: 'Kilogram per second',
+      plural: 'Kilograms per second',
+    },
+    to_anchor: 1,
+  },
+  'kg/h': {
+    name: {
+      singular: 'Kilogram per hour',
+      plural: 'Kilograms per hour',
+    },
+    to_anchor: 1 / 3600,
+  },
+  'mt/h': {
+    name: {
+      singular: 'Ton per hour',
+      plural: 'Tons per hour',
+    },
+    to_anchor: 1 / 3.6,
+  },
+};
+
+const imperial: Record<MassFlowRateImperialUnits, Unit> = {
+  'lb/s': {
+    name: {
+      singular: 'Pound per second',
+      plural: 'Pounds per second',
+    },
+    to_anchor: 1,
+  },
+  'lb/h': {
+    name: {
+      singular: 'Pound per hour',
+      plural: 'Pounds per hour',
+    },
+    to_anchor: 1 / 3600,
+  },
+};
+
+const measure: Measure<MassFlowRateSystems, MassFlowRateUnits> = {
+  systems: {
+    metric,
+    imperial,
+  },
+  anchors: {
+    metric: {
+      imperial: {
+        ratio: 1 / 0.453592,
+      },
+    },
+    imperial: {
+      metric: {
+        ratio: 0.453592,
+      },
+    },
+  },
+};
+
+export default measure;


### PR DESCRIPTION
This PR adds support for mass flow calculations, commonly used in fuel consumption (e.g. on aircraft), most common units are `lb/h` or `PPH` in the US and `t/h` in Europe.

This is related to #87 and other aviation-related additions in previous releases.

References:
https://en.wikipedia.org/wiki/Pound_per_hour

(3rd time is the charm :sweat_smile: )