### PR TITLE
add Ws (Watt-second) and Wm (Watt-minute)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,8 @@ Packaged Units
 
 <details>
 <summary>Energy</summary>
+* Ws
+* Wm
 * Wh
 * mWh
 * kWh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "convert-units",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "convert-units",
-      "version": "3.0.0-beta.4",
+      "version": "3.0.0-beta.5",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.6",

--- a/src/__tests__/possibilities.test.ts
+++ b/src/__tests__/possibilities.test.ts
@@ -434,7 +434,7 @@ test('energy possibilities', () => {
     energy,
   });
   const actual = convert().possibilities('energy'),
-    expected = ['Wh', 'mWh', 'kWh', 'MWh', 'GWh', 'J', 'kJ', 'MJ', 'GJ'];
+    expected = ['Ws', 'Wm', 'Wh', 'mWh', 'kWh', 'MWh', 'GWh', 'J', 'kJ', 'MJ', 'GJ'];
   expect(actual.sort()).toEqual(expected.sort());
 });
 
@@ -744,6 +744,8 @@ test('all possibilities', () => {
       'VARh',
       'W',
       'week',
+      'Ws',
+      'Wm',
       'Wh',
       'yd',
       'yd2',

--- a/src/definitions/__tests__/energy.test.ts
+++ b/src/definitions/__tests__/energy.test.ts
@@ -1,6 +1,160 @@
 import configureMeasurements from '../..';
 import energy, { EnergySystems, EnergyUnits } from '../energy';
 
+test('Ws to Ws', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('Ws')).toBe(1);
+});
+
+test('Ws to Wm', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('Wm')).toBeCloseTo(0.016_667);
+});
+
+test('Ws to Wh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('Wh')).toBeCloseTo(0.000_277_778);
+});
+
+test('Ws to mWh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('mWh')).toBeCloseTo(0.277_778);
+});
+
+test('Ws to kWh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('kWh')).toBeCloseTo(0.000_277_778);
+});
+
+test('Ws to MWh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('MWh')).toBeCloseTo(0.000_000_277_778);
+});
+
+test('Ws to GWh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('GWh')).toBeCloseTo(0.000_000_000_277_778);
+});
+
+test('Ws to J', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('J')).toBe(1);
+});
+
+test('Ws to kJ', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('kJ')).toBe(0.001);
+});
+
+test('Ws to MJ', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('MJ')).toBe(0.000_001);
+});
+
+test('Ws to GJ', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Ws').to('GJ')).toBe(0.000_000_001);
+});
+
+test('Wm to Wm', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('Wm')).toBe(1);
+});
+
+test('Wm to Ws', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('Ws')).toBe(60);
+});
+
+test('Wm to Wh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('Wh')).toBeCloseTo(0.016667);
+});
+
+test('Wm to mWh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('mWh')).toBeCloseTo(16.666_67);
+});
+
+test('Wm to kWh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('kWh')).toBeCloseTo(0.000_016_667);
+});
+
+test('Wm to MWh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('MWh')).toBeCloseTo(0.000_000_016_667);
+});
+
+test('Wm to GWh', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('GWh')).toBeCloseTo(0.000_000_000_016_667);
+});
+
+test('Wm to J', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('J')).toBe(60);
+});
+
+test('Wm to kJ', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('kJ')).toBe(0.06);
+});
+
+test('Wm to MJ', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('MJ')).toBe(0.000_06);
+});
+
+test('Wm to GJ', () => {
+  const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
+    energy,
+  });
+  expect(convert(1).from('Wm').to('GJ')).toBe(0.000_000_06);
+});
+
 test('Wh to Wh', () => {
   const convert = configureMeasurements<'energy', EnergySystems, EnergyUnits>({
     energy,

--- a/src/definitions/energy.ts
+++ b/src/definitions/energy.ts
@@ -3,6 +3,8 @@ export type EnergyUnits = EnergySIUnits;
 export type EnergySystems = 'SI';
 
 export type EnergySIUnits =
+  | 'Ws'
+  | 'Wm'
   | 'Wh'
   | 'mWh'
   | 'kWh'
@@ -14,6 +16,20 @@ export type EnergySIUnits =
   | 'GJ';
 
 const SI: Record<EnergySIUnits, Unit> = {
+  Ws: {
+    name: {
+      singular: 'Watt-second',
+      plural: 'Watt-seconds',
+    },
+    to_anchor: 1,
+  },
+  Wm: {
+    name: {
+      singular: 'Watt-minute',
+      plural: 'Watt-minutes',
+    },
+    to_anchor: 60,
+  },
   Wh: {
     name: {
       singular: 'Watt-hour',


### PR DESCRIPTION
Some smart plugs report the energy usage in Ws/Wm