### PR TITLE
:recycle: Correct form of non-abbreviated kelvin scale.

### DIFF
--- a/src/definitions/temperature.ts
+++ b/src/definitions/temperature.ts
@@ -18,8 +18,8 @@ const metric: Record<TemperatureMetricUnits, Unit> = {
   },
   K: {
     name: {
-      singular: 'degree Kelvin',
-      plural: 'degrees Kelvin',
+      singular: 'Kelvin',
+      plural: 'Kelvins',
     },
     to_anchor: 1,
     anchor_shift: 273.15,


### PR DESCRIPTION
As per Wikipedia (https://en.wikipedia.org/wiki/Kelvin), the Kelvin scale is never measured in "degrees". Instead, the name is usually pluralized (e.g. "kelvins") to refer to multiple units within this scale. While it isn't supposed to be capitalized, common writing trends tend to capitalize all units of temperature measurement, so this was retained from the original version.