### PR TITLE
chore: replace ts-ignore with ts-expect-error

### DIFF
--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -39,7 +39,7 @@ test('Should ignore exclude values that are not in the list of possibilities', (
       // Have to ignore TS errors since providing an invalid string to exclude
       // will cause the compiler to fail
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error
       .toBest({ exclude: ['not_possible'] }),
     expected = {
       val: 1.2,

--- a/src/__tests__/incompatibilities.test.ts
+++ b/src/__tests__/incompatibilities.test.ts
@@ -14,7 +14,7 @@ test('l to kg throws', () => {
   });
   expect(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     convert(2).from('ltr').to('kg');
   }).toThrow();
 });
@@ -28,8 +28,6 @@ test('fl-oz to oz throws', () => {
     mass,
   });
   expect(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     convert(4).from('fl-oz').to('oz');
   }).toThrow();
 });
@@ -43,8 +41,6 @@ test('kg to fl-oz throws', () => {
     mass,
   });
   expect(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     convert(4).from('kg').to('fl-oz');
   }).toThrow();
 });
@@ -58,8 +54,6 @@ test('kg to ft throws', () => {
     mass,
   });
   expect(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     convert(4).from('kg').to('ft');
   }).toThrow();
 });
@@ -70,7 +64,7 @@ test('kg to nonexistant unit throws', () => {
   });
   expect(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     convert(4).from('kg').to('garbage');
   }).toThrow();
 });
@@ -81,7 +75,7 @@ test('nonexistant unit to kg throws', () => {
   });
   expect(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     convert(4).from('garbage').to('kg');
   }).toThrow();
 });
@@ -217,7 +211,7 @@ test('Missing system to system anchor should throw an error', () => {
 
 test('passing no measures to configureMeasurements should cause calling convert to throw an error', () => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   const convert = configureMeasurements();
   expect(() => {
     convert();

--- a/src/__tests__/list.test.ts
+++ b/src/__tests__/list.test.ts
@@ -131,7 +131,7 @@ test('unsupported measure should throw', () => {
   const convert = configureMeasurements({});
   expect(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     convert().list('BadMeasure');
   }).toThrow();
 });


### PR DESCRIPTION
As per TS docs,it is recommended to use ts-expect-error instead of ts-ignore in test files when a type error is expected.