### PR TITLE
Rework package.json

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -30,5 +30,3 @@ jobs:
       run: npm run compile
     - name: Run publint
       run: npm run publint
-    - name: Typecheck
-      uses: andoshin11/typescript-error-reporter-action@v1.0.2

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [18.x, 20.x, 21.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,5 +26,9 @@ jobs:
       run: npm run lint
     - name: Run tests
       run: npm run test
+    - name: Compile Source
+      run: npm run compile
+    - name: Run publint
+      run: npm run publint
     - name: Typecheck
       uses: andoshin11/typescript-error-reporter-action@v1.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,12 @@ scratch
 *.swp
 
 coverage
-lib
+lib/*
+!lib/**/
+lib/umd/*
+lib/esm/*
+lib/cjs/*
+lib/types/*
+!lib/esm/package.json
+!lib/cjs/package.json
 convert-units-*.tgz

--- a/lib/cjs/package.json
+++ b/lib/cjs/package.json
@@ -1,0 +1,1 @@
+{"type": "commonjs"}

--- a/lib/esm/package.json
+++ b/lib/esm/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "jest": "^28.1.3",
         "prettier": "^2.7.1",
         "prettier-plugin-organize-imports": "^3.0.3",
+        "publint": "^0.2.7",
         "ts-jest": "^28.0.7",
         "typescript": "^4.7.4"
       }
@@ -3328,6 +3329,39 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-walk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-5.0.1.tgz",
+      "integrity": "sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4548,6 +4582,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4585,6 +4628,85 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-bundled": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-2.0.1.tgz",
+      "integrity": "sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==",
+      "dev": true,
+      "dependencies": {
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
+      "integrity": "sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm-packlist": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.1.3.tgz",
+      "integrity": "sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^8.0.1",
+        "ignore-walk": "^5.0.1",
+        "npm-bundled": "^2.0.0",
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "bin": {
+        "npm-packlist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm-packlist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/npm-packlist/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm-packlist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm-run-path": {
@@ -5020,6 +5142,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/publint": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.2.7.tgz",
+      "integrity": "sha512-tLU4ee3110BxWfAmCZggJmCUnYWgPTr0QLnx08sqpLYa8JHRiOudd+CgzdpfU5x5eOaW2WMkpmOrFshRFYK7Mw==",
+      "dev": true,
+      "dependencies": {
+        "npm-packlist": "^5.1.3",
+        "picocolors": "^1.0.0",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5183,6 +5325,18 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-array-concat": {

--- a/package.json
+++ b/package.json
@@ -4,30 +4,27 @@
   "description": "Convert between quantities in different units",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
-  "types": "index.d.ts",
   "type": "module",
-  "typesVersions": {
-    ">=4.2": {
-      "*": [
-        "lib/types/*",
-        "lib/types/definitions/*"
-      ]
-    }
-  },
   "exports": {
     ".": {
       "import": {
-        "types": "./lib/types/index.d.ts",
+        "types": "./lib/esm/index.d.ts",
         "default": "./lib/esm/index.js"
       },
-      "require": "./lib/cjs/index.js"
+      "require": {
+        "types": "./lib/cjs/index.d.ts",
+        "default": "./lib/cjs/index.js"
+      }
     },
     "./definitions/*": {
       "import": {
-        "types": "./lib/types/definitions/*.d.ts",
+        "types": "./lib/esm/definitions/*.d.ts",
         "default": "./lib/esm/definitions/*.js"
       },
-      "require": "./lib/cjs/definitions/*.js"
+      "require": {
+        "types": "./lib/esm/definitions/*.d.ts",
+        "default": "./lib/cjs/definitions/*.js"
+      }
     },
     "./package.json": "./package.json"
   },
@@ -43,6 +40,7 @@
     "jest": "^28.1.3",
     "prettier": "^2.7.1",
     "prettier-plugin-organize-imports": "^3.0.3",
+    "publint": "^0.2.7",
     "ts-jest": "^28.0.7",
     "typescript": "^4.7.4"
   },
@@ -50,11 +48,11 @@
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "lint": "eslint src",
+    "publint": "publint",
     "format": "prettier --write src",
-    "compile": "tsc -p ./tsconfig.json && tsc -p ./tsconfig.cjs.json && tsc -p ./tsconfig.umd.json && tsc -p ./tsconfig.types.json"
+    "compile": "tsc -p ./tsconfig.json && tsc -p ./tsconfig.cjs.json && tsc -p ./tsconfig.umd.json"
   },
   "files": [
-    "lib/types/**/!(*.tsbuildinfo)",
     "lib/esm/**/!(*.tsbuildinfo)",
     "lib/cjs/**/!(*.tsbuildinfo)",
     "lib/umd/**/!(*.tsbuildinfo)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,10 @@
     "allowJs": false,
     "checkJs": false,
     "noImplicitAny": true,
-    "declaration": false,
+    "declaration": true,
     "outDir": "./lib/esm",
     "strict": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "typeRoots": [


### PR DESCRIPTION
The issue #302 recommended a tool called publint, which showed various issues with the project's package.json. Since I'm no expert when it comes to packaging, I think it would be very wise to follow the issue author's advice on fixing the publint errors/warnings and also running publint on PRs.

I think going forward, code changes should not cause errors or warning when publint is ran. Aside from the fact that this will aid in testing and also serve as a sanity check so that releases don't break and cause folks a ton of headaches.

This will also fix the node-ci action as it was trying to use node versions that haven't been released yet. I don't know why I added those and why I never tested it. :clown: