### PR TITLE
Update `toBest` to return the original value

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ convert(12000).from('mm').toBest();
 // { val: 12, unit: 'm', ... }
 ```
 
+> Note: The `toBest` method is *subjective* and **does not work for all measures**.
+
+If a *better* value is not found, then from unit is returned. This is also the case for zero:
+
+```js
+convert(1).from('mm').toBest();
+// { val: 1, unit: 'mm', ... }
+
+convert(0).from('mm').toBest();
+// { val: 0, unit: 'mm', ... }
+```
+
 Exclude units to get different results:
 
 ```js

--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -125,16 +125,6 @@ test('does not break when excluding from measurement', () => {
   expect(actual).toEqual(expected);
 });
 
-test('if all measurements are excluded return from', () => {
-  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
-    length,
-  });
-  const actual = convert(10)
-    .from('km')
-    .toBest({ exclude: ['mm', 'cm', 'dm', 'm', 'km', 'nm', 'μm'] });
-  expect(actual).toEqual(null);
-});
-
 test('pre-cut off number', () => {
   const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
     length,
@@ -177,7 +167,7 @@ test('post-cut off number', () => {
   expect(actual).toEqual(expected);
 });
 
-test('return null if all possible units are excluded', () => {
+test('return the original value/unit if all possible units are excluded', () => {
   const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
     length,
   });
@@ -185,7 +175,29 @@ test('return null if all possible units are excluded', () => {
   const actual = convertLenght
       .from('km')
       .toBest({ exclude: convertLenght.possibilities() }),
-    expected = null;
+    expected = {
+      val: 10,
+      unit: 'km',
+      singular: 'Kilometer',
+      plural: 'Kilometers',
+    };
+  expect(actual).toEqual(expected);
+});
+
+test('return the original value/unit the convert value is zero', () => {
+  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
+    length,
+  });
+  const convertLenght = convert(0);
+  const actual = convertLenght
+      .from('km')
+      .toBest({ exclude: convertLenght.possibilities() }),
+    expected = {
+      val: 0,
+      unit: 'km',
+      singular: 'Kilometer',
+      plural: 'Kilometers',
+    };
   expect(actual).toEqual(expected);
 });
 

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -253,6 +253,15 @@ export class Converter<
       }
     }
 
+    if (best == null) {
+      return {
+        val: this.val,
+        unit: this.origin.abbr,
+        singular: this.origin.unit.name.singular,
+        plural: this.origin.unit.name.plural,
+      };
+    }
+
     return best;
   }
 


### PR DESCRIPTION
This will update the `toBest` to require the original value/unit if a better value is not found. The previous behaviour was to return `null`. This will also be the case if the value is zero.

This will also add these cases to the documentation as well as add a note stating that the *best* value is subjective and that `toBest` does not work for all measures.

Tests were updated to reflect the changes and one test was removed because it was testing the same thing as another.