### PR TITLE
Preserve unit type in `toBest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jest": "^26.8.2",
         "eslint-plugin-prettier": "^4.2.1",
+        "expect-type": "^0.19.0",
         "jest": "^29.7.0",
         "prettier": "^2.7.1",
         "prettier-plugin-organize-imports": "^3.0.3",
@@ -3447,6 +3448,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-0.19.0.tgz",
+      "integrity": "sha512-piv9wz3IrAG4Wnk2A+n2VRCHieAyOSxrRLU872Xo6nyn39kYXKDALk4OcqnvLRnFvkz659CnWC8MWZLuuQnoqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.8.2",
     "eslint-plugin-prettier": "^4.2.1",
+    "expect-type": "^0.19.0",
     "jest": "^29.7.0",
     "prettier": "^2.7.1",
     "prettier-plugin-organize-imports": "^3.0.3",

--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -1,4 +1,5 @@
-import configureMeasurements from '..';
+import { expectTypeOf } from 'expect-type';
+import configureMeasurements, { type Converter } from '..';
 import length, { LengthSystems, LengthUnits } from '../definitions/length';
 import power, { PowerSystems, PowerUnits } from '../definitions/power';
 
@@ -276,16 +277,12 @@ test('best mm with negative numbers', () => {
   expect(actual).toEqual(expected);
 });
 
-function assertStaticType<T>(value: T): void {
-  // intentionally empty body; just used to ask TypeScript to check that
-  // `value` does have type `t`
-  value;
-}
-
-test('type of unit field matches configured units', () => {
-  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
-    length,
-  });
-  const best = convert(1200).from('mm').toBest();
-  assertStaticType<LengthUnits | undefined>(best?.unit);
+test("toBest method's return type should equal the desired return type", () => {
+  type toBestMethod = Converter<'length', LengthSystems, LengthUnits>['toBest'];
+  expectTypeOf<toBestMethod>().returns.toEqualTypeOf<{
+    val: number;
+    unit: LengthUnits;
+    singular: string;
+    plural: string;
+  } | null>();
 });

--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -13,8 +13,6 @@ test('best mm', () => {
       singular: 'Meter',
       plural: 'Meters',
     };
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _typedUnit: LengthUnits | undefined = actual?.unit; // should type-check
   expect(actual).toEqual(expected);
 });
 
@@ -276,4 +274,18 @@ test('best mm with negative numbers', () => {
       plural: 'Meters',
     };
   expect(actual).toEqual(expected);
+});
+
+function assertStaticType<T>(value: T): void {
+  // intentionally empty body; just used to ask TypeScript to check that
+  // `value` does have type `t`
+  value;
+}
+
+test('type of unit field matches configured units', () => {
+  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
+    length,
+  });
+  const best = convert(1200).from('mm').toBest();
+  assertStaticType<LengthUnits | undefined>(best?.unit);
 });

--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -13,6 +13,8 @@ test('best mm', () => {
       singular: 'Meter',
       plural: 'Meters',
     };
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _typedUnit: LengthUnits | undefined = actual?.unit; // should type-check
   expect(actual).toEqual(expected);
 });
 

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -38,9 +38,9 @@ export interface Measure<TSystems extends string, TUnits extends string> {
   anchors?: Partial<Record<TSystems, Partial<Record<TSystems, Anchor>>>>;
 }
 
-export interface BestResult {
+export interface BestResult<TUnits extends string = string> {
   val: number;
-  unit: string;
+  unit: TUnits;
   singular: string;
   plural: string;
 }
@@ -206,7 +206,7 @@ export class Converter<
     exclude?: (TUnits | (string & {}))[];
     cutOffNumber?: number;
     system?: TSystems | (string & {});
-  }): BestResult | null {
+  }): BestResult<TUnits> | null {
     if (this.origin == null)
       throw new OperationOrderError('.toBest must be called after .from');
 
@@ -222,7 +222,7 @@ export class Converter<
       system = options.system ?? this.origin.system;
     }
 
-    let best: BestResult | null = null;
+    let best: BestResult<TUnits> | null = null;
     /**
       Looks through every possibility for the 'best' available unit.
       i.e. Where the value has the fewest numbers before the decimal point,


### PR DESCRIPTION
The `BestResult` type now takes a type parameter `TUnits`, which defaults to `string` for backward compatibility. That way, users who have configured a measurement system with a custom unit type can preserve that unit type on `bestResult.unit`.

The code was already nicely set up for this, so no casts or refactors were needed, just enriching the types themselves.

Fixes #318.

Test Plan:
Type-level unit test added; running `npm test` passes with this change but fails if you revert the change to `src/convert.ts` only. It also fails if you change `actual?.unit` to `'wat'`, with an appropriate error message, so it's testing the right thing and is not vacuous.

wchargin-branch: tobest-preserve-unit-type
