### PR TITLE
Setting a more precise conversion from metric to imperial

### DIFF
--- a/src/definitions/__tests__/mass.test.ts
+++ b/src/definitions/__tests__/mass.test.ts
@@ -103,5 +103,12 @@ test('st to g', () => {
   const convert = configureMeasurements<'mass', MassSystems, MassUnits>({
     mass,
   });
-  expect(convert(3).from('st').to('g')).toBeCloseTo(19050.863999);
+  expect(convert(3).from('st').to('g')).toBeCloseTo(19050.87954);
+});
+
+test('kg to lb', () => {
+  const convert = configureMeasurements<'mass', MassSystems, MassUnits>({
+    mass,
+  });
+  expect(convert(4677.6713).from('kg').to('lb')).toBeCloseTo(10312.49996555277);
 });

--- a/src/definitions/mass.ts
+++ b/src/definitions/mass.ts
@@ -82,12 +82,12 @@ const measure: Measure<MassSystems, MassUnits> = {
   anchors: {
     metric: {
       imperial: {
-        ratio: 1 / 453.592,
+        ratio: 1 / 453.59237,
       },
     },
     imperial: {
       metric: {
-        ratio: 453.592,
+        ratio: 453.59237,
       },
     },
   },


### PR DESCRIPTION
The current conversion is missing two digests at the end.  Here is an example how the calculation goes wrong:
Math.round(4677.6713*(1/0.453592)) -> 10313
but the right would be 
Math.round(4677.6713*(1/0.45359237)) -> 10312

Please also check https://en.wikipedia.org/wiki/Pound_(mass), here it is stated that the conversion has an exact ratio of 0.45359237.