### PR TITLE
Small performance improvement

### DIFF
--- a/src/__tests__/incompatibilities.test.ts
+++ b/src/__tests__/incompatibilities.test.ts
@@ -203,13 +203,26 @@ test('Missing system to system anchor should throw an error', () => {
   }).toThrow();
 });
 
-test('passing no measures to configureMeasurements should cause calling convert to throw an error', () => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-expect-error
-  const convert = configureMeasurements();
+test('passing no measures to configureMeasurements should throw an error', () => {
   expect(() => {
-    convert();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    configureMeasurements();
   }).toThrow();
+});
+
+test('passing anything but an object to configureMeasurements should throw an error', () => {
+  expect(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    configureMeasurements(0);
+  }).toThrow();
+});
+
+test('passing an empty object to configureMeasurements should not throw an error', () => {
+  expect(() => {
+    configureMeasurements({});
+  }).not.toThrow();
 });
 
 test('Calling from again on the same instance should throw an error', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
-import configMeasurements, { Converter } from './convert.js';
-export default configMeasurements;
+export {
+  Converter,
+  IncompatibleUnitError,
+  MeasureStructureError,
+  OperationOrderError,
+  UnknownMeasureError,
+  UnknownUnitError,
+  configureMeasurements as default,
+} from './convert.js';
 export type {
   Anchor,
   BestResult,
   Conversion,
   Measure,
   Unit,
+  UnitCache,
   UnitDescription,
 } from './convert.js';
-export { Converter };


### PR DESCRIPTION
Updated the Converter class so that it accepts a unit cache. Then updated the getUnit method to use the cache. This will make the `to` and `from` methods execute a bit faster.

This also fixes the index imports as not everything that should have been exported was being exported. Also fixed the default name not matching the docs.