### PR TITLE
New Unit for Acceleration - Added g0 (Standard Gravity) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,7 @@ Packaged Units
 <summary>Acceleration</summary>
 * g (g-force)
 * m/s2
+* g0 (Standard Gravity)
 </details>
 
 <details>

--- a/src/__tests__/possibilities.test.ts
+++ b/src/__tests__/possibilities.test.ts
@@ -609,7 +609,7 @@ test('acceleration possibilities', () => {
     acceleration,
   });
   const actual = convert().possibilities('acceleration'),
-    expected = ['g-force', 'm/s2'];
+    expected = ['g-force', 'm/s2', 'g0'];
   expect(actual.sort()).toEqual(expected.sort());
 });
 
@@ -695,6 +695,7 @@ test('all possibilities', () => {
       'gal/s',
       'glas',
       'grad',
+      'g0',
       'GHz',
       'GVA',
       'GVAR',

--- a/src/definitions/__tests__/acceleration.test.ts
+++ b/src/definitions/__tests__/acceleration.test.ts
@@ -25,3 +25,27 @@ test('m/s2 to g', () => {
   });
   expect(convert(9.80665).from('m/s2').to('g-force')).toBe(1);
 });
+
+// Test for g0 to m/s2
+test('g0 to m/s2', () => {
+  const convert = configureMeasurements<
+    'acceleration',
+    AccelerationSystems,
+    AccelerationUnits
+  >({
+    acceleration,
+  });
+  expect(convert(1).from('g0').to('m/s2')).toBe(9.80665);
+});
+
+// Test for m/s2 to g0
+test('m/s2 to g0', () => {
+  const convert = configureMeasurements<
+    'acceleration',
+    AccelerationSystems,
+    AccelerationUnits
+  >({
+    acceleration,
+  });
+  expect(convert(9.80665).from('m/s2').to('g0')).toBe(1);
+});

--- a/src/definitions/acceleration.ts
+++ b/src/definitions/acceleration.ts
@@ -2,7 +2,7 @@ import { Measure, Unit } from './../index.js';
 export type AccelerationUnits = AccelerationMetricUnits;
 export type AccelerationSystems = 'metric';
 
-export type AccelerationMetricUnits = 'g-force' | 'm/s2';
+export type AccelerationMetricUnits = 'g-force' | 'm/s2' | 'g0';
 
 const metric: Record<AccelerationMetricUnits, Unit> = {
   'g-force': {
@@ -18,6 +18,13 @@ const metric: Record<AccelerationMetricUnits, Unit> = {
       plural: 'Metres per second squared',
     },
     to_anchor: 1,
+  },
+  g0: {
+    name: {
+      singular: 'Standard Gravity',
+      plural: 'Standard Gravities',
+    },
+    to_anchor: 9.80665,
   },
 };
 


### PR DESCRIPTION
I would like to contribute to by adding a new unit for acceleration. Currently, the package supports g-force and m/s² under the metric system. I propose adding the following unit:

**Standard Gravity (g0)**

Represents standard acceleration due to gravity, widely used in physics.
Conversion: 1 g0 = 9.80665 m/s².