### PR TITLE
Improve `toBest` when no candidates meet the cutoff

### DIFF
--- a/src/__tests__/best.test.ts
+++ b/src/__tests__/best.test.ts
@@ -165,6 +165,51 @@ test('post-cut off number', () => {
   expect(actual).toEqual(expected);
 });
 
+test('when no conversion meets the cut-off', () => {
+  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
+    length,
+  });
+  const actual = convert(0.5e-3).from('μm').toBest({ cutOffNumber: 1 }),
+    expected = {
+      val: 0.5,
+      unit: 'nm',
+      singular: 'Nanometer',
+      plural: 'Nanometers',
+    };
+  expect(actual).toEqual(expected);
+});
+
+test('when no conversion meets the cut-off, cross-system', () => {
+  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
+    length,
+  });
+  const inputInches = convert(0.5).from('nm').to('in');
+  const actual = convert(inputInches)
+      .from('in')
+      .toBest({ cutOffNumber: 1, system: 'metric' }),
+    expected = {
+      val: 0.5,
+      unit: 'nm',
+      singular: 'Nanometer',
+      plural: 'Nanometers',
+    };
+  expect(actual).toEqual(expected);
+});
+
+test('when no conversion meets the cut-off, negative', () => {
+  const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
+    length,
+  });
+  const actual = convert(-0.5e-3).from('μm').toBest({ cutOffNumber: -1 }),
+    expected = {
+      val: -0.5,
+      unit: 'nm',
+      singular: 'Nanometer',
+      plural: 'Nanometers',
+    };
+  expect(actual).toEqual(expected);
+});
+
 test('return the original value/unit if all possible units are excluded', () => {
   const convert = configureMeasurements<'length', LengthSystems, LengthUnits>({
     length,


### PR DESCRIPTION
This patch changes the semantics of `toBest`'s cut-off number in the case where no candidate conversion meets the cut-off. The old semantics could be described as:

> `toBest` finds the conversion whose scalar is closest to the cut-off,
> without exceeding it.

The new semantics can be described as:

> `toBest` finds the conversion whose scalar is closest to the cut-off,
> preferring to not exceed the cut-off if at all possible.

Consider a system with the units `["mm", "cm", "m"]`. If the user asks for the "best" representation of 0.01 cm, candidate answers are 0.1 mm, 0.01 cm, or 0.0001 m. Of these, none meets the standard cutoff of having a scalar value at least 1. But we can still see intuitively that 0.1 mm is the answer that would be most readable to a human.

Previously, this library at 3.0.0-beta.6 would return `null` in such a case, but at 3.0.0-beta.7 it returns the input value unchanged---even if it was in a different system of units than the one requested! Callers could work around the `null`-return behavior by doing extra logic in that case, but the change to just return the input made it possible to distinguish this "couldn't find an answer" case from one in which the input was legitimately the best result.

I believe that this behavior is more natural than the existing behavior when using the default cut-off of 1, and in a GitHub-wide code search I could not find any public examples of users setting the value to something other than 1.

This resolves #346 by making it so that we no longer need to call `toBest` with a cut-off value of 0. :-)

Test Plan:
All existing tests pass. Unit tests added, which fail before this commit and pass after it.

wchargin-branch: tobest-soft-cutoff
